### PR TITLE
make sure we checkout the correct branch if BUILDKITE_COMMIT is HEAD

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -38,7 +38,7 @@ checkout() {
   git fetch -v origin HEAD
   git config remote.origin.fetch
   git fetch -v --prune origin "${BUILDKITE_BRANCH}"
-  if [[ "${BUILDKITE_COMMIT}" == "HEAD" ]]; then
+  if [[ -z "${BUILDKITE_COMMIT:-}" || "${BUILDKITE_COMMIT}" == "HEAD" ]]; then
     git checkout -f FETCH_HEAD
   else
     git checkout -f "${BUILDKITE_COMMIT}"

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -38,7 +38,11 @@ checkout() {
   git fetch -v origin HEAD
   git config remote.origin.fetch
   git fetch -v --prune origin "${BUILDKITE_BRANCH}"
-  git checkout -f "${BUILDKITE_COMMIT}"
+  if [[ "${BUILDKITE_COMMIT}" == "HEAD" ]]; then
+    git checkout -f FETCH_HEAD
+  else
+    git checkout -f "${BUILDKITE_COMMIT}"
+  fi
 }
 
 clean_checkout_dir() {


### PR DESCRIPTION
this will at least make sure we stay in the same branch even if the head moves during the build.

we still need to handle the case of commit id being `HEAD`, but this at least will improve things.