### PR TITLE
Add timeout for git remote operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# OSX filesystem journaling files.
+.DS_Store
+
+# IntelliJ project folder.
+.idea

--- a/README.md
+++ b/README.md
@@ -1,2 +1,41 @@
 # github-fetch-buildkite-plugin
-A Buildkite plugin to fecth a branch from github
+
+A [Buildkite](https://buildkite.com) plugin to fetch a branch from GitHub.
+
+## Buildkite Agent Requirements
+
+- [Git](https://git-scm.com/)
+- [Timeout (coreutils)](http://man7.org/linux/man-pages/man1/timeout.1.html)
+- [AWS CLI](https://aws.amazon.com/cli/) (only if `BUILDKITE_PLUGIN_GITHUB_FETCH_S3_URL` is provided)
+
+## Configurations
+
+The plugin accepts the following environment variables to configure its behaviour:
+
+- `BUILDKITE_PLUGIN_GITHUB_FETCH_S3_URL`
+    - Required: No
+    - Description: An S3 URL (e.g. `s3://<bucket>/<key>`) pointing to a "directory" in S3 which contains
+        snapshots of the GitHub repository to checkout. The snapshots must be in `tar.gz` format and use the following
+        naming convention: `YYYYMMDD_HHmmss.tar.gz`.
+
+    **Note**: If this parameter is not specified the branch will be always checked out from the repository in GitHub.
+
+- `BUILDKITE_PLUGIN_GITHUB_FETCH_GIT_REMOTE_TIMEOUT`
+    - Required: No
+    - Default: 0 (no timeout)
+    - Description: The maximum amount of time for Git remote operations (`push` `pull` `fetch`) to complete.
+
+- `BUILDKITE_PLUGIN_GITHUB_FETCH_GIT_REMOTE_TIMEOUT_EXIT_CODE`:
+    - Required: No
+    - Default: 110
+    - Description: The exit code returned by the Buildkite step if any Git remote operation times out.
+
+    **Note**: This parameter has no effect if `BUILDKITE_PLUGIN_GITHUB_FETCH_GIT_REMOTE_TIMEOUT` is undefined or
+    set to `0`.
+
+## Exit Codes
+
+| Exit Code        | Description     
+| ----------- |:-------------------------------------------------------------:
+| 116         | The target Git branch does not contain the specified commit. 
+      

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
 
-set -eu
+set -euo pipefail
+
+# The maximum amount of time (in seconds) that a remote Git operation (fetch, pull, push) can take.
+# If not specified by the user, no timeout will be applied to Git remote operations.
+GIT_REMOTE_TIMEOUT="${BUILDKITE_PLUGIN_GITHUB_FETCH_GIT_REMOTE_TIMEOUT:-0}"
+
+# Here is the exit code to be returned by this script when a remote Git operations times out.
+# Having a specific exit code for these scenarions allows to configure Buildkite pipelines to retry
+# the whole step without hiding underlying issues.
+# See: https://buildkite.com/docs/pipelines/command-step#automatic-retry-attributes
+#
+# If not specified by the user, it defaults to 110 which is the standard exit code for connection timeout.
+GIT_REMOTE_TIMEOUT_EXIT_CODE="${BUILDKITE_PLUGIN_GITHUB_FETCH_GIT_REMOTE_TIMEOUT_EXIT_CODE:-110}"
 
 # Checks if an env var is set
 # Arguments:
@@ -13,20 +25,39 @@ check_set() {
   fi
 }
 
+# Checks for failed exit codes returned by a timeout command.
+# If the underlying command fails due to timeout, this function stops the current execution returning either the
+# TIMEOUT exit code (124) or the override value provided by the caller.
+# In any other non-timeout failure scenarios, the current execution is stopped but the underlying command's exit
+# code is returned unmodified.
+# Arguments:
+#   $1: The exit code returned by the timeout command.
+#   $2: The exit code to be returned when the underlying command times out.
+check_timeout_exit_code() {
+  local exit_code="$1"
+  local timeout_exit_code_override="${2:-}"
+  if [[ "${exit_code}" -eq 124 && -n "${timeout_exit_code_override}" ]]; then
+    exit "${timeout_exit_code_override}"
+  elif [[ "${exit_code}" -ne 0 ]]; then
+    exit "${exit_code}"
+  fi
+}
+
 copy_checkout_from_s3() {
   local s3_url="$1"
+  local checkout
 
   clean_checkout_dir
 
-  local checkout
-
-  # find most recent checkout
+  # Find the most recent checkout in S3.
   checkout=$(aws s3 ls "${s3_url}/" \
       | (sort -r -k 4 || true) \
       | head -n1 \
       | awk '{print $4}'
   )
+
   pushd .. >/dev/null
+  # shellcheck disable=SC2064
   trap "rm ${PWD}/${checkout}" EXIT
   aws s3 cp "${s3_url}/${checkout}" "${PWD}/${checkout}"
   tar -zxf "${PWD}/${checkout}"
@@ -34,18 +65,22 @@ copy_checkout_from_s3() {
 }
 
 checkout() {
+  local exit_code=0
   git reset --hard
   git clean -ffxdq
-  git fetch -v origin HEAD
+
+  timeout "${GIT_REMOTE_TIMEOUT}" git fetch -v origin HEAD || exit_code=$?
+  check_timeout_exit_code "${exit_code}" "${GIT_REMOTE_TIMEOUT_EXIT_CODE}"
   git config remote.origin.fetch
-  git fetch -v --prune origin "${BUILDKITE_BRANCH}"
+  timeout "${GIT_REMOTE_TIMEOUT}" git fetch -v --prune origin "${BUILDKITE_BRANCH}" || exit_code=$?
+  check_timeout_exit_code "${exit_code}" "${GIT_REMOTE_TIMEOUT_EXIT_CODE}"
+
   if [[ -z "${BUILDKITE_COMMIT:-}" || "${BUILDKITE_COMMIT}" == "HEAD" ]]; then
     git checkout -f FETCH_HEAD
   else
     # If the branch doesn't have the commit we want it might have been force
     # pushed in the meantime. Exit with ESTALE to signify the stale branch
     # reference in that case.
-    local exit_code=0
     git checkout -f "${BUILDKITE_COMMIT}" || exit_code=$?
     if [[ "${exit_code}" -eq 128 ]]; then
       exit 116
@@ -62,9 +97,11 @@ clean_checkout_dir() {
 }
 
 clone() {
-  # git clone needs an empty directory
+  local exit_code=0
+  # The git clone operation needs an empty directory.
   clean_checkout_dir
-  git clone "${BUILDKITE_REPO}" .
+  timeout "${GIT_REMOTE_TIMEOUT}" git clone "${BUILDKITE_REPO}" . || exit_code=$?
+  check_timeout_exit_code "${exit_code}" "${GIT_REMOTE_TIMEOUT_EXIT_CODE}"
 }
 
 setup_git_lfs() {


### PR DESCRIPTION
## Intent
To add a configuration knob to allow users to define timeout for `Git` remote operations.

## Problem
If GitHub is flaky, the git remote operations (fetch, pull, push) block for quite a long time and then either fail or cause the whole checkout step to time out.

## Proposal
To leverage the `coreutils`'s `timeout` command so that we can fail fast when GitHub is experiencing issues and return a particular exit code so that Buildkite can be configured to perform automatic retries.

## Extra
- Added / updated documentation.
- Added basic `.gitignore`.