### PR TITLE
Fetch only the specific commit.

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -69,22 +69,27 @@ checkout() {
   git reset --hard
   git clean -ffxdq
 
-  timeout "${GIT_REMOTE_TIMEOUT}" git fetch -v origin HEAD || exit_code=$?
-  check_timeout_exit_code "${exit_code}" "${GIT_REMOTE_TIMEOUT_EXIT_CODE}"
   git config remote.origin.fetch
-  timeout "${GIT_REMOTE_TIMEOUT}" git fetch -v --prune origin "${BUILDKITE_BRANCH}" || exit_code=$?
-  check_timeout_exit_code "${exit_code}" "${GIT_REMOTE_TIMEOUT_EXIT_CODE}"
 
   if [[ -z "${BUILDKITE_COMMIT:-}" || "${BUILDKITE_COMMIT}" == "HEAD" ]]; then
+    timeout "${GIT_REMOTE_TIMEOUT}" git fetch -v origin "${BUILDKITE_BRANCH}" || exit_code=$?
+    check_timeout_exit_code "${exit_code}" "${GIT_REMOTE_TIMEOUT_EXIT_CODE}"
     git checkout -f FETCH_HEAD
   else
-    # If the branch doesn't have the commit we want it might have been force
-    # pushed in the meantime. Exit with ESTALE to signify the stale branch
-    # reference in that case.
+    # If the commit isn't reachable the ref that was pointint to it might have
+    # been force pushed in the meantime. Exit with ESTALE to signify the stale
+    # branch reference in that case.
+    timeout "${GIT_REMOTE_TIMEOUT}" git fetch -v origin "${BUILDKITE_BRANCH}" || exit_code=$?
+    check_timeout_exit_code "${exit_code}" "${GIT_REMOTE_TIMEOUT_EXIT_CODE}"
+    if [[ "${exit_code}" -eq 128 ]]; then
+      exit 116
+    elif [[ "${exit_code}" -ne 0 ]]; then
+      exit "${exit_code}"
+    fi
     git checkout -f "${BUILDKITE_COMMIT}" || exit_code=$?
     if [[ "${exit_code}" -eq 128 ]]; then
       exit 116
-    else
+    elif [[ "${exit_code}" -ne 0 ]]; then
       exit "${exit_code}"
     fi
   fi


### PR DESCRIPTION
This allows for better caching when we have a lot of jobs fetching the same commit: instead of checking the ref upstream every time we can fetch the commit we care about, regardless of which commit the ref is pointing to.