### PR TITLE
Make fetching specific commit safer.

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -75,17 +75,23 @@ checkout() {
     timeout "${GIT_REMOTE_TIMEOUT}" git fetch -v origin "${BUILDKITE_BRANCH}" || exit_code=$?
     check_timeout_exit_code "${exit_code}" "${GIT_REMOTE_TIMEOUT_EXIT_CODE}"
     git checkout -f FETCH_HEAD
+  elif git cat-file -e "${BUILDKITE_COMMIT}"; then
+    git checkout -f "${BUILDKITE_COMMIT}"
   else
-    # If the commit isn't reachable the ref that was pointint to it might have
-    # been force pushed in the meantime. Exit with ESTALE to signify the stale
-    # branch reference in that case.
     timeout "${GIT_REMOTE_TIMEOUT}" git fetch -v origin "${BUILDKITE_COMMIT}" || exit_code=$?
     check_timeout_exit_code "${exit_code}" "${GIT_REMOTE_TIMEOUT_EXIT_CODE}"
-    if [[ "${exit_code}" -eq 128 ]]; then
-      exit 116
-    elif [[ "${exit_code}" -ne 0 ]]; then
-      exit "${exit_code}"
+    # If checking out the commit fails, it might be because the commit isn't
+    # being advertised. In that case fetch the branch instead.
+    if [[ "${exit_code}" -ne 0 ]]; then
+      timeout "${GIT_REMOTE_TIMEOUT}" git fetch -v origin "${BUILDKITE_BRANCH}" || exit_code=$?
+      check_timeout_exit_code "${exit_code}" "${GIT_REMOTE_TIMEOUT_EXIT_CODE}"
+      if [[ "${exit_code}" -ne 0 ]]; then
+        exit "${exit_code}"
+      fi
     fi
+    # If the commit isn't reachable the ref that was pointing to it might have
+    # been force pushed in the meantime. Exit with ESTALE to signify the stale
+    # branch reference in that case.
     git checkout -f "${BUILDKITE_COMMIT}" || exit_code=$?
     if [[ "${exit_code}" -eq 128 ]]; then
       exit 116


### PR DESCRIPTION
Handles this kind of error:
```
error: Server does not allow request for unadvertised object abcde12345
```