### PR TITLE
Always set exit_code.

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -65,34 +65,39 @@ copy_checkout_from_s3() {
 }
 
 checkout() {
-  local exit_code=0
+  local exit_code
   git reset --hard
   git clean -ffxdq
 
   git config remote.origin.fetch
 
   if [[ -z "${BUILDKITE_COMMIT:-}" || "${BUILDKITE_COMMIT}" == "HEAD" ]]; then
-    timeout "${GIT_REMOTE_TIMEOUT}" git fetch -v origin "${BUILDKITE_BRANCH}" || exit_code=$?
+    timeout "${GIT_REMOTE_TIMEOUT}" git fetch -v origin "${BUILDKITE_BRANCH}" ; exit_code=$?
     check_timeout_exit_code "${exit_code}" "${GIT_REMOTE_TIMEOUT_EXIT_CODE}"
     git checkout -f FETCH_HEAD
   elif git cat-file -e "${BUILDKITE_COMMIT}"; then
     git checkout -f "${BUILDKITE_COMMIT}"
   else
-    timeout "${GIT_REMOTE_TIMEOUT}" git fetch -v origin "${BUILDKITE_COMMIT}" || exit_code=$?
+    timeout "${GIT_REMOTE_TIMEOUT}" git fetch -v origin "${BUILDKITE_COMMIT}" ; exit_code=$?
     check_timeout_exit_code "${exit_code}" "${GIT_REMOTE_TIMEOUT_EXIT_CODE}"
+    # If the commit isn't there the ref that was pointing to it might have
+    # been force pushed in the meantime. Exit with ESTALE to signify the stale
+    # branch reference in that case.
+    if [[ "${exit_code}" -eq 128 ]]; then
+      exit 116
     # If checking out the commit fails, it might be because the commit isn't
     # being advertised. In that case fetch the branch instead.
-    if [[ "${exit_code}" -ne 0 ]]; then
-      timeout "${GIT_REMOTE_TIMEOUT}" git fetch -v origin "${BUILDKITE_BRANCH}" || exit_code=$?
+    elif [[ "${exit_code}" -ne 0 ]]; then
+      timeout "${GIT_REMOTE_TIMEOUT}" git fetch -v origin "${BUILDKITE_BRANCH}" ; exit_code=$?
       check_timeout_exit_code "${exit_code}" "${GIT_REMOTE_TIMEOUT_EXIT_CODE}"
       if [[ "${exit_code}" -ne 0 ]]; then
         exit "${exit_code}"
       fi
     fi
-    # If the commit isn't reachable the ref that was pointing to it might have
+    # If the commit doesn't exist the ref that was pointing to it might have
     # been force pushed in the meantime. Exit with ESTALE to signify the stale
     # branch reference in that case.
-    git checkout -f "${BUILDKITE_COMMIT}" || exit_code=$?
+    git checkout -f "${BUILDKITE_COMMIT}" ; exit_code=$?
     if [[ "${exit_code}" -eq 128 ]]; then
       exit 116
     elif [[ "${exit_code}" -ne 0 ]]; then
@@ -108,10 +113,10 @@ clean_checkout_dir() {
 }
 
 clone() {
-  local exit_code=0
+  local exit_code
   # The git clone operation needs an empty directory.
   clean_checkout_dir
-  timeout "${GIT_REMOTE_TIMEOUT}" git clone "${BUILDKITE_REPO}" . || exit_code=$?
+  timeout "${GIT_REMOTE_TIMEOUT}" git clone "${BUILDKITE_REPO}" . ; exit_code=$?
   check_timeout_exit_code "${exit_code}" "${GIT_REMOTE_TIMEOUT_EXIT_CODE}"
 }
 


### PR DESCRIPTION
`exit_code` was being set only on command failure, which meant that if it wasn't reset to `0` explicitly previous failing exit codes could carry over successful commands. To fix this always set `exit_code` to the commands' exit code regardless of whether they fail or succeed.