### PR TITLE
Add BUILDKITE_PLUGIN_GITHUB_FETCH_BASH_PREFIX to help debugging.

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+if [[ -n "${BUILDKITE_PLUGIN_GITHUB_FETCH_BASH_PREFIX:-}" ]]; then
+  eval "${BUILDKITE_PLUGIN_GITHUB_FETCH_BASH_PREFIX}"
+fi
+
 # The maximum amount of time (in seconds) that a remote Git operation (fetch, pull, push) can take.
 # If not specified by the user, no timeout will be applied to Git remote operations.
 GIT_REMOTE_TIMEOUT="${BUILDKITE_PLUGIN_GITHUB_FETCH_GIT_REMOTE_TIMEOUT:-0}"


### PR DESCRIPTION
This can for example be set to `set -x` to enable tracing, or even `export GIT_TRACE=1; set -x` to enable both bash tracing and git tracing.