### PR TITLE
Reset exit code.

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -76,13 +76,15 @@ checkout() {
   git config remote.origin.fetch
 
   if [[ -z "${BUILDKITE_COMMIT:-}" || "${BUILDKITE_COMMIT}" == "HEAD" ]]; then
-    timeout "${GIT_REMOTE_TIMEOUT}" git fetch -v origin "${BUILDKITE_BRANCH}" ; exit_code=$?
+    exit_code=0
+    timeout "${GIT_REMOTE_TIMEOUT}" git fetch -v origin "${BUILDKITE_BRANCH}" || exit_code=$?
     check_timeout_exit_code "${exit_code}" "${GIT_REMOTE_TIMEOUT_EXIT_CODE}"
     git checkout -f FETCH_HEAD
   elif git cat-file -e "${BUILDKITE_COMMIT}"; then
     git checkout -f "${BUILDKITE_COMMIT}"
   else
-    timeout "${GIT_REMOTE_TIMEOUT}" git fetch -v origin "${BUILDKITE_COMMIT}" ; exit_code=$?
+    exit_code=0
+    timeout "${GIT_REMOTE_TIMEOUT}" git fetch -v origin "${BUILDKITE_COMMIT}" || exit_code=$?
     check_timeout_exit_code "${exit_code}" "${GIT_REMOTE_TIMEOUT_EXIT_CODE}"
     # If the commit isn't there the ref that was pointing to it might have
     # been force pushed in the meantime. Exit with ESTALE to signify the stale
@@ -92,7 +94,8 @@ checkout() {
     # If checking out the commit fails, it might be because the commit isn't
     # being advertised. In that case fetch the branch instead.
     elif [[ "${exit_code}" -ne 0 ]]; then
-      timeout "${GIT_REMOTE_TIMEOUT}" git fetch -v origin "${BUILDKITE_BRANCH}" ; exit_code=$?
+      exit_code=0
+      timeout "${GIT_REMOTE_TIMEOUT}" git fetch -v origin "${BUILDKITE_BRANCH}" || exit_code=$?
       check_timeout_exit_code "${exit_code}" "${GIT_REMOTE_TIMEOUT_EXIT_CODE}"
       if [[ "${exit_code}" -ne 0 ]]; then
         exit "${exit_code}"
@@ -101,7 +104,8 @@ checkout() {
     # If the commit doesn't exist the ref that was pointing to it might have
     # been force pushed in the meantime. Exit with ESTALE to signify the stale
     # branch reference in that case.
-    git checkout -f "${BUILDKITE_COMMIT}" ; exit_code=$?
+    exit_code=0
+    git checkout -f "${BUILDKITE_COMMIT}" || exit_code=$?
     if [[ "${exit_code}" -eq 128 ]]; then
       exit 116
     elif [[ "${exit_code}" -ne 0 ]]; then
@@ -120,7 +124,8 @@ clone() {
   local exit_code
   # The git clone operation needs an empty directory.
   clean_checkout_dir
-  timeout "${GIT_REMOTE_TIMEOUT}" git clone "${BUILDKITE_REPO}" . ; exit_code=$?
+  exit_code=0
+  timeout "${GIT_REMOTE_TIMEOUT}" git clone "${BUILDKITE_REPO}" . || exit_code=$?
   check_timeout_exit_code "${exit_code}" "${GIT_REMOTE_TIMEOUT_EXIT_CODE}"
 }
 


### PR DESCRIPTION
https://github.com/arromer/github-fetch-buildkite-plugin/pull/15 didn't handle this correctly as it would exit the script because of `set -e`. Instead reset it to 0 every time.