### PR TITLE
Use --notags to skip ref advertisement.

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -77,14 +77,14 @@ checkout() {
 
   if [[ -z "${BUILDKITE_COMMIT:-}" || "${BUILDKITE_COMMIT}" == "HEAD" ]]; then
     exit_code=0
-    timeout "${GIT_REMOTE_TIMEOUT}" git fetch -v origin "${BUILDKITE_BRANCH}" || exit_code=$?
+    timeout "${GIT_REMOTE_TIMEOUT}" git fetch -v --notags origin "${BUILDKITE_BRANCH}" || exit_code=$?
     check_timeout_exit_code "${exit_code}" "${GIT_REMOTE_TIMEOUT_EXIT_CODE}"
     git checkout -f FETCH_HEAD
   elif git cat-file -e "${BUILDKITE_COMMIT}"; then
     git checkout -f "${BUILDKITE_COMMIT}"
   else
     exit_code=0
-    timeout "${GIT_REMOTE_TIMEOUT}" git fetch -v origin "${BUILDKITE_COMMIT}" || exit_code=$?
+    timeout "${GIT_REMOTE_TIMEOUT}" git fetch -v --notags origin "${BUILDKITE_COMMIT}" || exit_code=$?
     check_timeout_exit_code "${exit_code}" "${GIT_REMOTE_TIMEOUT_EXIT_CODE}" || exit_code=$?
     # If the commit isn't there the ref that was pointing to it might have
     # been force pushed in the meantime. Exit with ESTALE to signify the stale
@@ -95,7 +95,7 @@ checkout() {
     # being advertised. In that case fetch the branch instead.
     elif [[ "${exit_code}" -ne 0 ]]; then
       exit_code=0
-      timeout "${GIT_REMOTE_TIMEOUT}" git fetch -v origin "${BUILDKITE_BRANCH}" || exit_code=$?
+      timeout "${GIT_REMOTE_TIMEOUT}" git fetch -v --notags origin "${BUILDKITE_BRANCH}" || exit_code=$?
       check_timeout_exit_code "${exit_code}" "${GIT_REMOTE_TIMEOUT_EXIT_CODE}"
     fi
     # If the commit doesn't exist the ref that was pointing to it might have


### PR DESCRIPTION
This uses `--notags` to reduce the amount of refs we query from the server.

Officially this prevents fetching tags of objects that are reachable: https://git-scm.com/docs/git-pull#Documentation/git-pull.txt---no-tags

Testing shows that without it when fetching a branch git will fetch all tags, but will then ignore the ones that aren't reachable (this is up to the server probably):

Without `--notags`
```
11:21:04.548790 git.c:439               trace: built-in: git fetch -v origin master
11:21:04.668223 run-command.c:663       trace: run_command: unset GIT_PREFIX; GIT_PROTOCOL=version=2 ssh -o SendEnv=GIT_PROTOCOL git@github.com 'git-upload-pack '\''Canva/canva.git'\'''
11:21:06.978276 pkt-line.c:80           packet:        fetch< version 2
11:21:06.978294 pkt-line.c:80           packet:        fetch< agent=git/github-gb3333e0720cb
11:21:06.978299 pkt-line.c:80           packet:        fetch< ls-refs
11:21:06.978302 pkt-line.c:80           packet:        fetch< fetch=shallow
11:21:06.978306 pkt-line.c:80           packet:        fetch< server-option
11:21:06.978308 pkt-line.c:80           packet:        fetch< 0000
11:21:06.978312 pkt-line.c:80           packet:        fetch> command=ls-refs
11:21:06.978321 pkt-line.c:80           packet:        fetch> agent=git/2.24.0
11:21:06.978324 pkt-line.c:80           packet:        fetch> 0001
11:21:06.978350 pkt-line.c:80           packet:        fetch> peel
11:21:06.978356 pkt-line.c:80           packet:        fetch> symrefs
11:21:06.978360 pkt-line.c:80           packet:        fetch> ref-prefix master
11:21:06.978364 pkt-line.c:80           packet:        fetch> ref-prefix refs/master
11:21:06.978367 pkt-line.c:80           packet:        fetch> ref-prefix refs/tags/master
11:21:06.978370 pkt-line.c:80           packet:        fetch> ref-prefix refs/heads/master
11:21:06.978374 pkt-line.c:80           packet:        fetch> ref-prefix refs/remotes/master
11:21:06.978384 pkt-line.c:80           packet:        fetch> ref-prefix refs/remotes/master/HEAD
11:21:06.978387 pkt-line.c:80           packet:        fetch> ref-prefix refs/tags/
11:21:06.978390 pkt-line.c:80           packet:        fetch> 0000
11:21:07.275129 pkt-line.c:80           packet:        fetch< cb511610d50c4622bb53e2ffc90df9a5bf3775d1 refs/heads/master
11:21:07.568708 pkt-line.c:80           packet:        fetch< 128008c443985504cf494f4c62ca55fe6a5ae4ed refs/tags/CA-1285
[ ... lots more tags ... ]
```
With `--notags`:
```
11:18:53.828437 git.c:439               trace: built-in: git fetch -v --no-tags origin master
11:18:53.975680 run-command.c:663       trace: run_command: unset GIT_PREFIX; GIT_PROTOCOL=version=2 ssh -o SendEnv=GIT_PROTOCOL git@github.com 'git-upload-pack '\''Canva/canva.git'\'''
11:18:56.186435 pkt-line.c:80           packet:        fetch< version 2
11:18:56.186495 pkt-line.c:80           packet:        fetch< agent=git/github-gb3333e0720cb
11:18:56.186506 pkt-line.c:80           packet:        fetch< ls-refs
11:18:56.186511 pkt-line.c:80           packet:        fetch< fetch=shallow
11:18:56.186516 pkt-line.c:80           packet:        fetch< server-option
11:18:56.186519 pkt-line.c:80           packet:        fetch< 0000
11:18:56.186523 pkt-line.c:80           packet:        fetch> command=ls-refs
11:18:56.186569 pkt-line.c:80           packet:        fetch> agent=git/2.24.0
11:18:56.186591 pkt-line.c:80           packet:        fetch> 0001
11:18:56.186621 pkt-line.c:80           packet:        fetch> peel
11:18:56.186629 pkt-line.c:80           packet:        fetch> symrefs
11:18:56.186633 pkt-line.c:80           packet:        fetch> ref-prefix master
11:18:56.186638 pkt-line.c:80           packet:        fetch> ref-prefix refs/master
11:18:56.186643 pkt-line.c:80           packet:        fetch> ref-prefix refs/tags/master
11:18:56.186646 pkt-line.c:80           packet:        fetch> ref-prefix refs/heads/master
11:18:56.186650 pkt-line.c:80           packet:        fetch> ref-prefix refs/remotes/master
11:18:56.186812 pkt-line.c:80           packet:        fetch> ref-prefix refs/remotes/master/HEAD
11:18:56.186822 pkt-line.c:80           packet:        fetch> 0000
11:18:56.482983 pkt-line.c:80           packet:        fetch< e32ec3bd439b22570a1c0a30b5a87bc49249940b refs/heads/master
11:18:56.593340 pkt-line.c:80           packet:        fetch< 0000
[...]
```

When fetching a specific commit the difference is even more extreme, as fetching a commit without `--notags` causes the client to run a `ls-refs` with no prefix, which returns all refs, including PR and merge refs:

```
17:15:09.060902 git.c:439               trace: built-in: git fetch origin 88d15aaebf3b5f878160af6a710f128b28b26f17
17:15:09.108652 run-command.c:663       trace: run_command: unset GIT_PREFIX; GIT_PROTOCOL=version=2 ssh -o SendEnv=GIT_PROTOCOL git@github.com 'git-upload-pack '\''Canva/canva.git'\'''
17:15:11.283551 pkt-line.c:80           packet:        fetch< version 2
17:15:11.283643 pkt-line.c:80           packet:        fetch< agent=git/github-g8d2486a6a867
17:15:11.283665 pkt-line.c:80           packet:        fetch< ls-refs
17:15:11.284328 pkt-line.c:80           packet:        fetch< fetch=shallow
17:15:11.284563 pkt-line.c:80           packet:        fetch< server-option
17:15:11.284586 pkt-line.c:80           packet:        fetch< 0000
17:15:11.284595 pkt-line.c:80           packet:        fetch> command=ls-refs
17:15:11.284610 pkt-line.c:80           packet:        fetch> agent=git/2.24.0
17:15:11.284617 pkt-line.c:80           packet:        fetch> 0001
17:15:11.284624 pkt-line.c:80           packet:        fetch> peel
17:15:11.284630 pkt-line.c:80           packet:        fetch> symrefs
17:15:11.284639 pkt-line.c:80           packet:        fetch> 0000
17:15:11.503010 pkt-line.c:80           packet:        fetch< 6a36e0201592e85ec223c441523574d0c5c4146b HEAD symref-target:refs/heads/master
17:15:15.459052 pkt-line.c:80           packet:        fetch< aa3e3c4e4d88b3af44c2a360c98f61bba43e2ec1 refs/head/steven-jooq-migration-2
[ ... lots and lots of refs ... ]
17:15:16.525827 pkt-line.c:80           packet:        fetch< 93a5186a0fa8294d98d3d3fbe67b548242fb91be refs/pull/11079/head
17:15:16.525833 pkt-line.c:80           packet:        fetch< 0af727496e16808632fd69811b8030eb9be842df refs/pull/1108/head
17:15:16.525840 pkt-line.c:80           packet:        fetch< 05114b9a7c3d34b039c9e621134f3773fb1c02d5 refs/pull/1108/merge
17:15:16.525846 pkt-line.c:80           packet:        fetch< 4b15178e11aa64ea85cae57bcdd1e4875daef918 refs/pull/11080/head
17:15:16.525853 pkt-line.c:80           packet:        fetch< c5b3468dd6bb13dabcdbc3d60bb2269fb2f7ef8b refs/pull/11080/merge
17:15:16.525859 pkt-line.c:80           packet:        fetch< c8597423132d7c2d399a86ad88e4d6538e38fd0a refs/pull/11081/head
17:15:16.525866 pkt-line.c:80           packet:        fetch< 0984a7aa22c2bd9f80f8a9fea5242b771bf6c782 refs/pull/11081/merge
17:15:16.525872 pkt-line.c:80           packet:        fetch< aa4ee35d7c8448ce95907c212a4426f9f1a41160 refs/pull/11082/head
17:15:16.525879 pkt-line.c:80           packet:        fetch< 7cb4e9cbadba5c247c8be4136b3c515ef9ffe657 refs/pull/11083/head
17:15:16.525886 pkt-line.c:80           packet:        fetch< b8096fd944e2fc6a9bfdf70980ee87e4bbcb6802 refs/pull/11084/head
17:15:16.525893 pkt-line.c:80           packet:        fetch< f0da66e1e5773172e69e4d1e38479f9bc511b9aa refs/pull/11085/head
17:15:16.525900 pkt-line.c:80           packet:        fetch< d43c9f052366653e49c09eac2eb78f55d0cffe71 refs/pull/11086/head
17:15:16.525907 pkt-line.c:80           packet:        fetch< fa6663e827a91738a7093962e7438413de3ba785 refs/pull/11087/head
17:15:16.525913 pkt-line.c:80           packet:        fetch< c26f90537131329d395146745c73651a40aa6eb6 refs/pull/11088/head
17:15:16.525920 pkt-line.c:80           packet:        fetch< 999a8ee9e52349aaeab6aaa3a310a79dd2e72563 refs/pull/11089/head
17:15:16.525926 pkt-line.c:80           packet:        fetch< 6c459505e95abd197d04ff9f180947358e964ef3 refs/pull/1109/head
17:15:16.525933 pkt-line.c:80           packet:        fetch< 33a1ccbe88a06ffd1837fe232dc0d63b58513662 refs/pull/1109/merge
17:15:16.525939 pkt-line.c:80           packet:        fetch< 35e108564250e385703c8ec04e90020bdaee9c9a refs/pull/11090/head
[ ... more refs ... ]
```

With `--notags` fetching a single commit will skip `ls-refs` entirely:

```
10:55:35.613064 git.c:439               trace: built-in: git fetch -v --no-tags origin b60755330c8095219cb2a14018df7402bdd2395f
10:55:35.744377 run-command.c:663       trace: run_command: unset GIT_PREFIX; GIT_PROTOCOL=version=2 ssh -o SendEnv=GIT_PROTOCOL git@github.com 'git-upload-pack '\''Canva/canva.git'\'''
10:55:37.870284 pkt-line.c:80           packet:        fetch< version 2
10:55:37.870346 pkt-line.c:80           packet:        fetch< agent=git/github-g8d2486a6a867
10:55:37.870357 pkt-line.c:80           packet:        fetch< ls-refs
10:55:37.870366 pkt-line.c:80           packet:        fetch< fetch=shallow
10:55:37.870375 pkt-line.c:80           packet:        fetch< server-option
10:55:37.870383 pkt-line.c:80           packet:        fetch< 0000
10:55:38.585992 pkt-line.c:80           packet:        fetch> command=fetch
10:55:38.586520 pkt-line.c:80           packet:        fetch> agent=git/2.24.0
10:55:38.586534 pkt-line.c:80           packet:        fetch> 0001
10:55:38.586538 pkt-line.c:80           packet:        fetch> thin-pack
10:55:38.586540 pkt-line.c:80           packet:        fetch> no-progress
10:55:38.586543 pkt-line.c:80           packet:        fetch> ofs-delta
10:55:38.586548 pkt-line.c:80           packet:        fetch> want b60755330c8095219cb2a14018df7402bdd2395f
[...]
`