### PR TITLE
Fix --no-tags.

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -77,14 +77,14 @@ checkout() {
 
   if [[ -z "${BUILDKITE_COMMIT:-}" || "${BUILDKITE_COMMIT}" == "HEAD" ]]; then
     exit_code=0
-    timeout "${GIT_REMOTE_TIMEOUT}" git fetch -v --notags origin "${BUILDKITE_BRANCH}" || exit_code=$?
+    timeout "${GIT_REMOTE_TIMEOUT}" git fetch -v --no-tags origin "${BUILDKITE_BRANCH}" || exit_code=$?
     check_timeout_exit_code "${exit_code}" "${GIT_REMOTE_TIMEOUT_EXIT_CODE}"
     git checkout -f FETCH_HEAD
   elif git cat-file -e "${BUILDKITE_COMMIT}"; then
     git checkout -f "${BUILDKITE_COMMIT}"
   else
     exit_code=0
-    timeout "${GIT_REMOTE_TIMEOUT}" git fetch -v --notags origin "${BUILDKITE_COMMIT}" || exit_code=$?
+    timeout "${GIT_REMOTE_TIMEOUT}" git fetch -v --no-tags origin "${BUILDKITE_COMMIT}" || exit_code=$?
     check_timeout_exit_code "${exit_code}" "${GIT_REMOTE_TIMEOUT_EXIT_CODE}" || exit_code=$?
     # If the commit isn't there the ref that was pointing to it might have
     # been force pushed in the meantime. Exit with ESTALE to signify the stale
@@ -95,7 +95,7 @@ checkout() {
     # being advertised. In that case fetch the branch instead.
     elif [[ "${exit_code}" -ne 0 ]]; then
       exit_code=0
-      timeout "${GIT_REMOTE_TIMEOUT}" git fetch -v --notags origin "${BUILDKITE_BRANCH}" || exit_code=$?
+      timeout "${GIT_REMOTE_TIMEOUT}" git fetch -v --no-tags origin "${BUILDKITE_BRANCH}" || exit_code=$?
       check_timeout_exit_code "${exit_code}" "${GIT_REMOTE_TIMEOUT_EXIT_CODE}"
     fi
     # If the commit doesn't exist the ref that was pointing to it might have


### PR DESCRIPTION
Added in https://github.com/arromer/github-fetch-buildkite-plugin/pull/19 the flag is `--no-tags`, not `--notags`.