### PR TITLE
Revert "add support to replace repo base url"

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -18,9 +18,6 @@ GIT_REMOTE_TIMEOUT="${BUILDKITE_PLUGIN_GITHUB_FETCH_GIT_REMOTE_TIMEOUT:-0}"
 # If not specified by the user, it defaults to 110 which is the standard exit code for connection timeout.
 GIT_REMOTE_TIMEOUT_EXIT_CODE="${BUILDKITE_PLUGIN_GITHUB_FETCH_GIT_REMOTE_TIMEOUT_EXIT_CODE:-110}"
 
-# URL for access to the repository
-GIT_REPO="${BUILDKITE_PLUGIN_GITHUB_FETCH_URL_INSTEADOF:-${BUILDKITE_REPO}}"
-
 # Prints an info line to stdout.
 log_info() {
   echo "$(date '+[%Y-%m-%d %H:%M:%S]') INFO: $*"
@@ -138,7 +135,7 @@ clone() {
   # The git clone operation needs an empty directory.
   clean_checkout_dir
   exit_code=0
-  timeout "${GIT_REMOTE_TIMEOUT}" git clone "${GIT_REPO}" . || exit_code=$?
+  timeout "${GIT_REMOTE_TIMEOUT}" git clone "${BUILDKITE_REPO}" . || exit_code=$?
   check_timeout_exit_code "${exit_code}" "${GIT_REMOTE_TIMEOUT_EXIT_CODE}"
   log_info "Cloning from github done"
 }
@@ -156,13 +153,6 @@ main() {
   check_set BUILDKITE_BRANCH
   check_set BUILDKITE_COMMIT
   check_set BUILDKITE_BUILD_CHECKOUT_PATH
-
-  # set git repo but keep the LFS URL
-  echo "setting repo origin to ${GIT_REPO}"
-  git remote set-url origin "${GIT_REPO}"
-
-  echo "setting LFS URL to ${BUILDKITE_REPO}"
-  git config lfs.url "${BUILDKITE_REPO}"
 
   local git_lfs_skip_smudge_was_set=true
   (env | grep --quiet GIT_LFS_SKIP_SMUDGE=) || git_lfs_skip_smudge_was_set=false
@@ -191,11 +181,6 @@ main() {
   else
     unset GIT_LFS_SKIP_SMUDGE
   fi
-
-  # set git repo back to its original value
-  echo "setting repo origin to ${BUILDKITE_REPO}"
-  git remote set-url origin "${BUILDKITE_REPO}"
-
 }
 
 main "$@"


### PR DESCRIPTION
Reverts arromer/github-fetch-buildkite-plugin#22

reverting this so that if we update the plugin it doesn't carry the checkout logic change.