### PR TITLE
Checkout Metadata

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -181,6 +181,8 @@ main() {
   else
     unset GIT_LFS_SKIP_SMUDGE
   fi
+
+  buildkite-agent meta-data set "checkout_success" 0 --job "${BUILDKITE_JOB_ID}"
 }
 
 main "$@"


### PR DESCRIPTION
Using the buildkite agent to set a piece of metadata which can be used by subsequent steps to check whether a checkout executed successfully.