### PR TITLE
enable checkout using a github app

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -210,8 +210,6 @@ main() {
     setup_git_lfs
   fi
 
-  git remote set-url origin "${BUILDKITE_REPO}"
-
   checkout
 
   if [[ "${git_lfs_skip_smudge_was_set}" == "true" ]]; then

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -179,7 +179,7 @@ setup_git_lfs() {
   if [[ "${BUILDKITE_REPO}" =~ .*github\.com.* ]]; then
     # Workaround for GitHub git-lfs API rate limit error:
     # https://github.com/git-lfs/git-lfs/issues/2133#issuecomment-292557138
-    git config "lfs.https://github.com/${BUILDKITE_REPO#git@github.com:}/info/lfs.access" basic
+    git config "lfs.https://github.com/${BUILDKITE_REPO#*@github.com:}/info/lfs.access" basic
   fi
   # make sure that the lfs hooks & filters are installed locally in the repo
   # in case they have not been installed in the S3 copy
@@ -202,6 +202,9 @@ main() {
   fi
 
   initialize_local_repo
+
+  # set origin in case the repo was changed by the pre-checkout hook
+  git remote set-url origin "${BUILDKITE_REPO}"
 
   if command -v git-lfs >/dev/null; then
     setup_git_lfs

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -11,7 +11,7 @@ export_buildkite_repo() {
   local out_file
   out_file=$(mktemp)
   # shellcheck disable=SC2064
-  trap "rm ${out_file}" EXIT
+  trap "rm '${out_file}'" EXIT
 
   AWS_PAGER='' aws lambda invoke \
       --region us-east-1 \

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+export_buildkite_repo() {
+  local payload
+  payload=$(jq -n --arg AppID "${BUILDKITE_PLUGIN_GITHUB_FETCH_APP_ID}" \
+            --arg SecretId "${BUILDKITE_PLUGIN_GITHUB_FETCH_APP_SECRET}" \
+            '{$AppID, $SecretId}')
+
+  local out_file
+  out_file=$(mktemp)
+  # shellcheck disable=SC2064
+  trap "rm ${out_file}" EXIT
+
+  AWS_PAGER='' aws lambda invoke \
+      --region us-east-1 \
+      --function-name github-app-token \
+      --payload "${payload}" \
+      "${out_file}"
+
+  local token
+  token=$(jq -r '.body' <"${out_file}" | jq -r '.token')
+
+  # Converts repo url from git@github.com:Org/repo to https://x-access-token:token@github.com/Org/repo
+  export BUILDKITE_REPO="https://x-access-token:${token}@github.com/${BUILDKITE_REPO#*@github.com:}"
+}
+
+main() {
+  if [[ -n "${BUILDKITE_PLUGIN_GITHUB_FETCH_APP_ID:-}" ]] && [[ -n "${BUILDKITE_PLUGIN_GITHUB_FETCH_APP_SECRET:-}" ]]; then
+    export_buildkite_repo
+  fi
+}
+
+main "$@"

--- a/plugin.yml
+++ b/plugin.yml
@@ -3,4 +3,12 @@ description: Fetchs a branch from a github repository
 author: https://github.com/arromer
 requirements:
   - buildkite-agent
+configuration:
+  properties:
+    s3_url:
+      type: string
+    app_id:
+      type: number
+    app_secret:
+      type: string
 public: true


### PR DESCRIPTION
Add a pre-checkout hook so that we can use a github app to do the checkout instead of using SSH keys from the agent.

tested here: https://buildkite.com/canva-org/canva-web-build/builds/329147