### PR TITLE
set remote url before checkout

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -207,6 +207,8 @@ main() {
     setup_git_lfs
   fi
 
+  git remote set-url origin "${BUILDKITE_REPO}"
+
   checkout
 
   if [[ "${git_lfs_skip_smudge_was_set}" == "true" ]]; then


### PR DESCRIPTION
this sets the origin url to the one in `BUILDKITE_REPO`, in case the checkout in the agent has a different origin.