### PR TITLE
fix lambda invoke on aws cli v2

### DIFF
--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -49,9 +49,11 @@ export_buildkite_repo() {
   # shellcheck disable=SC2064
   trap "rm '${out_file}'" EXIT
 
+  # when running aws cli v2, --cli-binary-format raw-in-base64-out is required
   AWS_PAGER='' aws lambda invoke \
       --region us-east-1 \
       --function-name github-app-token \
+      --cli-binary-format raw-in-base64-out \
       --payload "${payload}" \
       "${out_file}"
 


### PR DESCRIPTION
this fixes an issue when invoking a lambda using the aws cli v2:
```
Invalid base64: "{
  "AppID": "85068",
  "SecretId": "/nix-ci/github/app_private_key"
}"
```

cli v2 requires passing the `--cli-binary-format raw-in-base64-out` parameter.

All agents are being migrated to use aws cli v2, so we need to update this to be able to checkout the repo using a github app.