### PR TITLE
fix: do not warn about detached checkout

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -96,6 +96,7 @@ checkout() {
   git status
 
   git config remote.origin.fetch
+  git config advice.detachedHead false
 
   if [[ -z "${BUILDKITE_COMMIT:-}" || "${BUILDKITE_COMMIT}" == "HEAD" ]]; then
     exit_code=0


### PR DESCRIPTION
This will fix:

```
[2021-02-04 22:39:19] INFO: Starting git config.
+refs/heads/*:refs/remotes/origin/*
Note: switching to 'SHA'.
 
You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.
 
If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:
 
  git switch -c <new-branch-name>
 
Or undo this operation with:
 
  git switch -
 
Turn off this advice by setting config variable advice.detachedHead to false
 
HEAD is now at SHA blabla
[2021-02-04 22:39:19] INFO: Checkout done
```