### PR TITLE
Fix retry in checkout hook

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -275,7 +275,7 @@ main() {
     fi
 
     log_info "main:Checkout failed with error code=${exit_code}. retry=${retry}"
-    retry=$((retry++))
+    retry=$((retry + 1))
 
     if [[ "${retry}" -ge "${max_retry}" ]]; then
       log_info "main:Maximum retry reached."

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -275,7 +275,7 @@ main() {
     fi
 
     log_info "main:Checkout failed with error code=${exit_code}. retry=${retry}"
-    ((retry++))
+    retry=$((retry++))
 
     if [[ "${retry}" -ge "${max_retry}" ]]; then
       log_info "main:Maximum retry reached."


### PR DESCRIPTION
retries are not working:

```
[2021-04-08 02:00:49] INFO: Fetch BUILDKITE_COMMIT=b5abee35f11f8b57b20c5ef54b6553283c0d1375
--
  | [2021-04-08 02:06:50] INFO: Commit SHA b5abee35f11f8b57b20c5ef54b6553283c0d1375 does not exists. The ref might have been force pushed.
  | [2021-04-08 02:06:50] INFO: main:Checkout failed with error code=116. retry=0
  | 2021-04-08 02:06:50 INFO   Found 1 files that match "/tmp/githublog.7a1ljov7Xb.log"
```

the problem seems to be this:
```
$ retry=0
$ ((retry++))
$ echo $?
1
$ echo "${retry}"
1
```

with this fix:
```
$ retry=0
$ retry=$((retry + 1))
$ echo $?
0
$ echo "${retry}"
1
```
