### PR TITLE
add support for git proxy

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -177,13 +177,13 @@ checkout() {
     log_info "Using proxy: ${proxy_url}"
     git config http.proxy "${proxy_url}"
     git config url."http://github.com/".insteadOf git@github.com:
-    git config protocol.version 2
   else
     log_info "Not using proxy"
     git config --unset http.proxy
     git config --unset url."http://github.com/".insteadof
   fi
 
+  git config protocol.version 2
   git reset --hard
   git clean -ffxdq
 

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -176,11 +176,12 @@ checkout() {
   if [[ -n "${proxy_url:-}" ]]; then
     log_info "Using proxy: ${proxy_url}"
     git config http.proxy "${proxy_url}"
-    git config url."https://github.com/".insteadOf git@github.com:
+    git config url."http://github.com/".insteadOf git@github.com:
+    git config protocol.version 2
   else
     log_info "Not using proxy"
     git config --unset http.proxy
-    git config --unset url."https://github.com/".insteadof
+    git config --unset url."http://github.com/".insteadof
   fi
 
   git reset --hard

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -31,11 +31,15 @@ GIT_REMOTE_TIMEOUT_EXIT_CODE="${BUILDKITE_PLUGIN_GITHUB_FETCH_GIT_REMOTE_TIMEOUT
 # Otherwise it will re-use a cached copy from S3 for the first time or re-use the local repository.
 BUILDKITE_CLEAN_CHECKOUT="${BUILDKITE_CLEAN_CHECKOUT:-false}"
 
+PROXY_URL_SSM_PARAM="${GH_CONTROL_USER_ENV_GITHUB_CHECKOUT_PLUGIN_PROXY_URL_SSM_PARAM:-${BUILDKITE_PLUGIN_GITHUB_FETCH_PROXY_URL_SSM_PARAM:-/github/git-proxy/url}}"
+
 
 # Invoke mktemp in a way which works on macOS and GNU/Linux
 git_log=$(mktemp "${TMPDIR:-/tmp/}githublog.XXXXXXXXXX")
 
 PLUGIN_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd)"
+
+OUTFILE=$(mktemp)
 
 # Prints an info line to stdout.
 log_info() {
@@ -84,6 +88,7 @@ exit_handler() {
   else
     log_info "Git log file '${git_log}' not found."
   fi
+  rm ${OUTFILE}
 }
 
 copy_checkout_from_s3() {
@@ -131,6 +136,35 @@ copy_checkout_from_s3() {
   log_info "Copying from S3 done"
 }
 
+# prints the major version of the aws cli running
+print_aws_version() {
+    local version
+    version=$(aws --version 2>&1)
+    [[ "${version}" =~ ^aws-cli\/([0-9])\.[0-9]+.[0-9]+ ]]
+    echo "${BASH_REMATCH[1]}"
+}
+
+print_proxy_url() {
+  local aws_version
+  aws_version=$(print_aws_version)
+  local -a params
+  if [[ "${aws_version}" == "2" ]]; then
+    params=(--cli-binary-format raw-in-base64-out)
+  else
+    params=()
+  fi
+  local lambda_output
+  lambda_output=(aws lambda invoke \
+      --region us-east-1 \
+      --function-name ssm-cache \
+      --payload "{\"ssm_param\": \"${SSM_PARAM}\"}" \
+      "${params[@]}" "${OUTFILE}")
+  if [[ $(jq -r 'has("FunctionError")' <<< "${lambda_output}") == "false" ]]; then
+    # if no error in response, print message
+    jq -r '.body | fromjson | .message' < "${OUTFILE}"
+  fi
+}
+
 checkout() {
   log_info "Starting checkout"
 
@@ -139,6 +173,14 @@ checkout() {
 
   git reset --hard
   git clean -ffxdq
+
+  local proxy_url
+  proxy_url=$(print_proxy_url)
+  if [[ -n "${proxy_url:-}" ]]; then
+    echo "Using proxy: ${proxy_url}"
+  else
+    echo "Not using proxy"
+  fi
 
 
   # Check the current state to make sure we start from a clean working tree.

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -186,7 +186,7 @@ print_proxy_url() {
     local rollout
     rollout=$(print_ssm_param "${proxy_rollout_param}")
     echo "proxy rollout param is ${rollout}" 1>&2
-    if [[ -n "${rollout:-}" && $((1 + $RANDOM % 100)) -le "${rollout}" ]];
+    if [[ -n "${rollout:-}" && $((1 + $RANDOM % 100)) -le "${rollout}" ]]; then
       echo "${proxy_url}"
     fi
   fi

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -178,8 +178,13 @@ checkout() {
   proxy_url=$(print_proxy_url)
   if [[ -n "${proxy_url:-}" ]]; then
     echo "Using proxy: ${proxy_url}"
+    git config http.proxy "${proxy_url}"
+    git config url."https://github.com/".insteadOf git@github.com:
+    git config url."https://".insteadOf git://
   else
     echo "Not using proxy"
+    git config --unset http.proxy
+    git config --unset url."https://github.com/".insteadof
   fi
 
 

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -207,7 +207,7 @@ checkout() {
   else
     log_info "Not using proxy"
     git config --unset http.proxy
-    git config --unset url."http://github.com/".insteadof
+    git config --unset url."http://github.com/".insteadOf
   fi
 
   git config protocol.version 2

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -171,9 +171,6 @@ checkout() {
   local exit_code
   exit_code=0
 
-  git reset --hard
-  git clean -ffxdq
-
   local proxy_url
   proxy_url=$(print_proxy_url)
   if [[ -n "${proxy_url:-}" ]]; then
@@ -186,6 +183,8 @@ checkout() {
     git config --unset url."https://github.com/".insteadof
   fi
 
+  git reset --hard
+  git clean -ffxdq
 
   # Check the current state to make sure we start from a clean working tree.
   # This does both "refresh the index and updating the cached stat information"

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -32,6 +32,7 @@ GIT_REMOTE_TIMEOUT_EXIT_CODE="${BUILDKITE_PLUGIN_GITHUB_FETCH_GIT_REMOTE_TIMEOUT
 BUILDKITE_CLEAN_CHECKOUT="${BUILDKITE_CLEAN_CHECKOUT:-false}"
 
 PROXY_URL_SSM_PARAM="${GH_CONTROL_USER_ENV_GITHUB_CHECKOUT_PLUGIN_PROXY_URL_SSM_PARAM:-${BUILDKITE_PLUGIN_GITHUB_FETCH_PROXY_URL_SSM_PARAM:-/github/git-proxy/url}}"
+PROXY_ROLLOUT_SSM_PARAM="${GH_CONTROL_USER_ENV_GITHUB_CHECKOUT_PLUGIN_PROXY_ROLLOUT_SSM_PARAM:-${BUILDKITE_PLUGIN_GITHUB_FETCH_PROXY_ROLLOUT_SSM_PARAM:-/github/git-proxy/rollout}}"
 
 
 # Invoke mktemp in a way which works on macOS and GNU/Linux
@@ -91,8 +92,15 @@ exit_handler() {
   rm "${OUTFILE}"
 }
 
+print_repo_dir() {
+  grep -Eo '([a-zA-Z0-9-]+\/[a-zA-Z0-9-]+)' <<< "${BUILDKITE_REPO}" \
+      | tr '[:upper:]' '[:lower:]' \
+      | sed 's/\//__/g'
+}
+
 copy_checkout_from_s3() {
-  local s3_url="$1"
+  local repo_dir=$(print_repo_dir)
+  local s3_url="${1}/repo_dir"
   local checkout
 
   log_info "Getting checkout from S3"
@@ -144,7 +152,8 @@ print_aws_version() {
     echo "${BASH_REMATCH[1]}"
 }
 
-print_proxy_url() {
+print_ssm_param(){
+  local ssm_param="${1}"
   local aws_version
   aws_version=$(print_aws_version)
   local -a params
@@ -157,11 +166,29 @@ print_proxy_url() {
   lambda_output=$(aws lambda invoke \
       --region us-east-1 \
       --function-name ssm-cache \
-      --payload "{\"ssm_param\": \"${PROXY_URL_SSM_PARAM}\"}" \
+      --payload "{\"ssm_param\": \"${ssm_param}\"}" \
       "${params[@]}" "${OUTFILE}")
   if [[ $(jq -r 'has("FunctionError")' <<< "${lambda_output}") == "false" ]]; then
     # if no error in response, print message
     jq -r '.body | fromjson | .message' < "${OUTFILE}"
+  fi
+}
+
+print_proxy_url() {
+  local proxy_url
+  proxy_url=$(print_ssm_param "${PROXY_URL_SSM_PARAM}")
+  echo "proxy url param is ${proxy_url}" 1>&2
+  if [[ -n "${proxy_url:-}" ]]; then
+    local repo_dir
+    repo_dir=$(print_repo_dir)
+    local proxy_rollout_param="${PROXY_ROLLOUT_SSM_PARAM}/${repo_dir}"
+
+    local rollout
+    rollout=$(print_ssm_param "${proxy_rollout_param}")
+    echo "proxy rollout param is ${rollout}" 1>&2
+    if [[ -n "${rollout:-}" && $((1 + $RANDOM % 100)) -le "${rollout}" ]];
+      echo "${proxy_url}"
+    fi
   fi
 }
 

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -157,7 +157,7 @@ print_proxy_url() {
   lambda_output=(aws lambda invoke \
       --region us-east-1 \
       --function-name ssm-cache \
-      --payload "{\"ssm_param\": \"${SSM_PARAM}\"}" \
+      --payload "{\"ssm_param\": \"${PROXY_URL_SSM_PARAM}\"}" \
       "${params[@]}" "${OUTFILE}")
   if [[ $(jq -r 'has("FunctionError")' <<< "${lambda_output}") == "false" ]]; then
     # if no error in response, print message

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -177,11 +177,11 @@ checkout() {
   local proxy_url
   proxy_url=$(print_proxy_url)
   if [[ -n "${proxy_url:-}" ]]; then
-    echo "Using proxy: ${proxy_url}"
+    log_info "Using proxy: ${proxy_url}"
     git config http.proxy "${proxy_url}"
     git config url."https://github.com/".insteadOf git@github.com:
   else
-    echo "Not using proxy"
+    log_info "Not using proxy"
     git config --unset http.proxy
     git config --unset url."https://github.com/".insteadof
   fi

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -88,7 +88,7 @@ exit_handler() {
   else
     log_info "Git log file '${git_log}' not found."
   fi
-  rm ${OUTFILE}
+  rm "${OUTFILE}"
 }
 
 copy_checkout_from_s3() {

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -154,7 +154,7 @@ print_proxy_url() {
     params=()
   fi
   local lambda_output
-  lambda_output=(aws lambda invoke \
+  lambda_output=$(aws lambda invoke \
       --region us-east-1 \
       --function-name ssm-cache \
       --payload "{\"ssm_param\": \"${PROXY_URL_SSM_PARAM}\"}" \

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -180,7 +180,6 @@ checkout() {
     echo "Using proxy: ${proxy_url}"
     git config http.proxy "${proxy_url}"
     git config url."https://github.com/".insteadOf git@github.com:
-    git config url."https://".insteadOf git://
   else
     echo "Not using proxy"
     git config --unset http.proxy

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+main() {
+    if git config --get http.proxy; then
+        git config --unset http.proxy
+    fi
+    if git config --get url."http://github.com/".insteadof; then
+        git config --unset url."http://github.com/".insteadof
+    fi
+    if git config --get url."https://github.com/".insteadof; then
+        git config --unset url."https://github.com/".insteadof
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
During checkout:
- read ssm parameter using ssm-cache lambda to avoid rate limit issues
- if the parameter is set, use it as proxy in git config
- also change origin to use https instead of git protocol

If the ssm parameter is not set or there is a failure calling the lambda, the proxy setting is removed