### PR TITLE
fix print_repo_dir to parse github url in SSH or HTTP/HTTPS forms

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -93,9 +93,9 @@ exit_handler() {
 }
 
 print_repo_dir() {
-  grep -Eo '([a-zA-Z0-9-]+\/[a-zA-Z0-9-]+)' <<< "${BUILDKITE_REPO}" \
+  grep -Eo '([a-zA-Z0-9-]+\/[a-zA-Z0-9-]+)\.git' <<< "${BUILDKITE_REPO}" \
       | tr '[:upper:]' '[:lower:]' \
-      | sed 's/\//__/g'
+      | sed -e 's/.git$//' -e 's/\//__/g'
 }
 
 copy_checkout_from_s3() {


### PR DESCRIPTION
### Assumptions
This fix relies on that all forms of github URLs have `<owner>/<repo>.git` in it. 


### Tests
```
$ BUILDKITE_REPO=http://x-access-token:xxx@github.com/Canva/infrastructure.git bash test.sh                     
canva__infrastructure
$ BUILDKITE_REPO=https://github.com/Canva/infrastructure.git bash test.sh    
canva__infrastructure
$ BUILDKITE_REPO=org-2562356@github.com:Canva/infrastructure.git bash test.sh
canva__infrastructure
$ BUILDKITE_REPO=git@github.com:Canva/infrastructure.git bash test.sh
canva__infrastructure
$ BUILDKITE_REPO=git@github.com:Canva/infra-apps.git bash test.sh
canva__infra-apps
```
