### PR TITLE
[CI-769] Setting proxy based on different protocols in BUILDKITE_REPO

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -192,6 +192,19 @@ print_proxy_url() {
   fi
 }
 
+unset_proxy() {
+  if git config --get-regexp 'http.*.proxy' > /dev/null; then
+    for name in $(git config --name-only --get-regexp 'http.*.proxy'); do
+      echo "unset ${name}"
+      git config --unset "${name}"
+    done
+  fi
+  if git config --get remote.origin.pushurl > /dev/null; then
+    echo "unset remote.origin.pushurl"
+    git config --unset remote.origin.pushurl
+  fi
+}
+
 checkout() {
   log_info "Starting checkout"
 
@@ -201,12 +214,40 @@ checkout() {
   local proxy_url
   proxy_url=$(print_proxy_url)
   if [[ -n "${proxy_url:-}" ]]; then
-    log_info "Using proxy: ${proxy_url}"
-    git config http.proxy "${proxy_url}"
-    git config remote.origin.url "http://github.com/${BUILDKITE_REPO#*@github.com:}"
-    git config remote.origin.pushurl "${BUILDKITE_REPO}"
+    if [[ "${BUILDKITE_REPO}" =~ ^https://.* ]]; then
+      # BUILDKITE_REPO is in https protocol
+      log_info "Using proxy: ${proxy_url}"
+      git config http."http://github.com/${BUILDKITE_REPO#*@github.com/}".proxy "${proxy_url}"
+      # convert https to http for pull
+      git config remote.origin.url "http://${BUILDKITE_REPO#https://}"
+      git config remote.origin.pushurl "${BUILDKITE_REPO}"
+    elif [[ "${BUILDKITE_REPO}" =~ ^http://.* ]]; then
+      # BUILDKITE_REPO is in http protocol
+      log_info "Using proxy: ${proxy_url}"
+      git config http."http://github.com/${BUILDKITE_REPO#*@github.com/}".proxy "${proxy_url}"
+      git config remote.origin.url "${BUILDKITE_REPO}"
+      # convert http to https for push
+      git config remote.origin.pushurl "https://${BUILDKITE_REPO#http://}"
+    elif [[ "${proxy_url}" =~ ^https://.* ]]; then
+      # BUILDKITE_REPO is in git protocol and proxy requires authentication
+      # since we don't have the token, we can't use the proxy
+      log_info "Not using proxy"
+      unset_proxy
+      git config remote.origin.url "${BUILDKITE_REPO}"
+    else
+      # BUILDKITE_REPO is in git protocol and proxy do not require authentication
+      # therefore we can still use proxy without the token
+      log_info "Using proxy: ${proxy_url}"
+      git config http."http://github.com/${BUILDKITE_REPO#*@github.com:}".proxy "${proxy_url}"
+      # convert git to http for pull
+      git config remote.origin.url "http://github.com/${BUILDKITE_REPO#*@github.com:}"
+      # keep the git url for push (existing behaviour)
+      git config remote.origin.pushurl "${BUILDKITE_REPO}"
+    fi
   else
     log_info "Not using proxy"
+    unset_proxy
+    git config remote.origin.url "${BUILDKITE_REPO}"
   fi
 
   git config protocol.version 2
@@ -327,7 +368,14 @@ setup_git_lfs() {
   if [[ "${CANVA_REPO}" =~ .*github\.com.* ]]; then
     # Workaround for GitHub git-lfs API rate limit error:
     # https://github.com/git-lfs/git-lfs/issues/2133#issuecomment-292557138
-    git config "lfs.https://github.com/${CANVA_REPO#*@github.com:}/info/lfs.access" basic
+    # Also setting both https and http URLs, so that if git-proxy requires http URL as remote it should still work.
+    if [[ "${CANVA_REPO}" =~ ^https?://.* ]]; then
+      git config "lfs.https://github.com/${CANVA_REPO#*@github.com/}/info/lfs.access" basic
+      git config "lfs.http://github.com/${CANVA_REPO#*@github.com/}/info/lfs.access" basic
+    else
+      git config "lfs.https://github.com/${CANVA_REPO#*@github.com:}/info/lfs.access" basic
+      git config "lfs.http://github.com/${CANVA_REPO#*@github.com:}/info/lfs.access" basic
+    fi
   fi
   # make sure that the lfs hooks & filters are installed locally in the repo
   # in case they have not been installed in the S3 copy

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -3,13 +3,17 @@
 set -euo pipefail
 
 main() {
-    if git config --get http.proxy; then
-        git config --unset http.proxy
-    fi
-    if git config --get remote.origin.pushurl; then
-        git config --unset remote.origin.pushurl
-    fi
-    git config remote.origin.url "${BUILDKITE_REPO}"
+  if git config --get-regexp 'http.*.proxy' > /dev/null; then
+    for name in $(git config --name-only --get-regexp 'http.*.proxy'); do
+      echo "unset ${name}"
+      git config --unset "${name}"
+    done
+  fi
+  if git config --get remote.origin.pushurl > /dev/null; then
+    echo "unset remote.origin.pushurl"
+    git config --unset remote.origin.pushurl
+  fi
+  git config remote.origin.url "${BUILDKITE_REPO}"
 }
 
 main "$@"


### PR DESCRIPTION
### Tests

```
GIVEN
BUILDKITE_REPO=org-2562356@github.com:Canva/infrastructure.git
proxy_url=http://git-proxy.canva-build.com:80
WILL DO
git remote set-url origin org-2562356@github.com:Canva/infrastructure.git
git config lfs.https://github.com/Canva/infrastructure.git/info/lfs.access basic
git config lfs.http://github.com/Canva/infrastructure.git/info/lfs.access basic
BUILDKITE_REPO is in git protocol and proxy do not requires authentication
Using proxy: http://git-proxy.canva-build.com:80
git config http."http://github.com/Canva/infrastructure.git".proxy http://git-proxy.canva-build.com:80
git config remote.origin.url http://github.com/Canva/infrastructure.git
git config remote.origin.pushurl org-2562356@github.com:Canva/infrastructure.git

GIVEN
BUILDKITE_REPO=git@github.com:Canva/infrastructure.git
proxy_url=http://git-proxy.canva-build.com:80
WILL DO
git remote set-url origin git@github.com:Canva/infrastructure.git
git config lfs.https://github.com/Canva/infrastructure.git/info/lfs.access basic
git config lfs.http://github.com/Canva/infrastructure.git/info/lfs.access basic
BUILDKITE_REPO is in git protocol and proxy do not requires authentication
Using proxy: http://git-proxy.canva-build.com:80
git config http."http://github.com/Canva/infrastructure.git".proxy http://git-proxy.canva-build.com:80
git config remote.origin.url http://github.com/Canva/infrastructure.git
git config remote.origin.pushurl git@github.com:Canva/infrastructure.git

GIVEN
BUILDKITE_REPO=https://x-access-token:ghs_12345@github.com/Canva/infrastructure.git
proxy_url=http://git-proxy.canva-build.com:80
WILL DO
git remote set-url origin https://x-access-token:ghs_12345@github.com/Canva/infrastructure.git
git config lfs.https://github.com/Canva/infrastructure.git/info/lfs.access basic
git config lfs.http://github.com/Canva/infrastructure.git/info/lfs.access basic
BUILDKITE_REPO is in https protocol
Using proxy: http://git-proxy.canva-build.com:80
git config http."http://github.com/Canva/infrastructure.git".proxy http://git-proxy.canva-build.com:80
git config remote.origin.url http://x-access-token:ghs_12345@github.com/Canva/infrastructure.git
git config remote.origin.pushurl https://x-access-token:ghs_12345@github.com/Canva/infrastructure.git

GIVEN
BUILDKITE_REPO=http://x-access-token:ghs_12345@github.com/Canva/infrastructure.git
proxy_url=http://git-proxy.canva-build.com:80
WILL DO
git remote set-url origin http://x-access-token:ghs_12345@github.com/Canva/infrastructure.git
git config lfs.https://github.com/Canva/infrastructure.git/info/lfs.access basic
git config lfs.http://github.com/Canva/infrastructure.git/info/lfs.access basic
BUILDKITE_REPO is in http protocol
Using proxy: http://git-proxy.canva-build.com:80
git config http."http://github.com/Canva/infrastructure.git".proxy http://git-proxy.canva-build.com:80
git config remote.origin.url http://x-access-token:ghs_12345@github.com/Canva/infrastructure.git
git config remote.origin.pushurl https://x-access-token:ghs_12345@github.com/Canva/infrastructure.git

GIVEN
BUILDKITE_REPO=org-2562356@github.com:Canva/infrastructure.git
proxy_url=https://git-proxy-2.canva-build.com
WILL DO
git remote set-url origin org-2562356@github.com:Canva/infrastructure.git
git config lfs.https://github.com/Canva/infrastructure.git/info/lfs.access basic
git config lfs.http://github.com/Canva/infrastructure.git/info/lfs.access basic
BUILDKITE_REPO is in git protocol and proxy requires authentication
Not using proxy
git config --unset http.*.proxy (note: will not work, need to loop instead)
git config --unset remote.origin.pushurl
git config remote.origin.url org-2562356@github.com:Canva/infrastructure.git

GIVEN
BUILDKITE_REPO=git@github.com:Canva/infrastructure.git
proxy_url=https://git-proxy-2.canva-build.com
WILL DO
git remote set-url origin git@github.com:Canva/infrastructure.git
git config lfs.https://github.com/Canva/infrastructure.git/info/lfs.access basic
git config lfs.http://github.com/Canva/infrastructure.git/info/lfs.access basic
BUILDKITE_REPO is in git protocol and proxy requires authentication
Not using proxy
git config --unset http.*.proxy (note: will not work, need to loop instead)
git config --unset remote.origin.pushurl
git config remote.origin.url git@github.com:Canva/infrastructure.git

GIVEN
BUILDKITE_REPO=https://x-access-token:ghs_12345@github.com/Canva/infrastructure.git
proxy_url=https://git-proxy-2.canva-build.com
WILL DO
git remote set-url origin https://x-access-token:ghs_12345@github.com/Canva/infrastructure.git
git config lfs.https://github.com/Canva/infrastructure.git/info/lfs.access basic
git config lfs.http://github.com/Canva/infrastructure.git/info/lfs.access basic
BUILDKITE_REPO is in https protocol
Using proxy: https://git-proxy-2.canva-build.com
git config http."http://github.com/Canva/infrastructure.git".proxy https://git-proxy-2.canva-build.com
git config remote.origin.url http://x-access-token:ghs_12345@github.com/Canva/infrastructure.git
git config remote.origin.pushurl https://x-access-token:ghs_12345@github.com/Canva/infrastructure.git

GIVEN
BUILDKITE_REPO=http://x-access-token:ghs_12345@github.com/Canva/infrastructure.git
proxy_url=https://git-proxy-2.canva-build.com
WILL DO
git remote set-url origin http://x-access-token:ghs_12345@github.com/Canva/infrastructure.git
git config lfs.https://github.com/Canva/infrastructure.git/info/lfs.access basic
git config lfs.http://github.com/Canva/infrastructure.git/info/lfs.access basic
BUILDKITE_REPO is in http protocol
Using proxy: https://git-proxy-2.canva-build.com
git config http."http://github.com/Canva/infrastructure.git".proxy https://git-proxy-2.canva-build.com
git config remote.origin.url http://x-access-token:ghs_12345@github.com/Canva/infrastructure.git
git config remote.origin.pushurl https://x-access-token:ghs_12345@github.com/Canva/infrastructure.git



```