### PR TITLE
report checkout duration to datadog agent

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -455,7 +455,9 @@ main() {
   test $? -eq 0 || log_info "Fail to log statistics. Ignore error."
 
   # report checkout duration to datadog agent
-  echo -n "github.checkout_time:${duration}|d" | nc -4u -w0 127.0.0.1 8125
+  local repo_dir
+  repo_dir=$(print_repo_dir)
+  echo -n "github.checkout_time:${duration}|d|repo:${repo_dir}" | nc -4u -w0 127.0.0.1 8125
 }
 
 main "$@"

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -454,6 +454,8 @@ main() {
   echo "{\"event_type\":\"github-plugin-stats\",\"repo_initialisation_method\":\"${INITILISATION_METHOD}\",\"duration\":\"${duration}\",\"retry\":\"${retry}\"}" | logger
   test $? -eq 0 || log_info "Fail to log statistics. Ignore error."
 
+  # report checkout duration to datadog agent
+  echo -n "github.checkout_time:${duration}|d" | nc -4u -w0 127.0.0.1 8125
 }
 
 main "$@"

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -457,7 +457,7 @@ main() {
   # report checkout duration to datadog agent
   local repo_dir
   repo_dir=$(print_repo_dir)
-  echo -n "github.checkout_time:${duration}|d|repo:${repo_dir}" | nc -4u -w0 127.0.0.1 8125
+  echo -n "github.checkout_time:${duration}|d|repo:${repo_dir}" | nc -4u -w0 127.0.0.1 8125 || true
 }
 
 main "$@"

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -457,7 +457,7 @@ main() {
   # report checkout duration to datadog agent
   local repo_dir
   repo_dir=$(print_repo_dir)
-  echo -n "github.checkout_time:${duration}|d|repo:${repo_dir}" | nc -4u -w0 127.0.0.1 8125 || true
+  echo -n "github.checkout_time:${duration}|d|#repo:${repo_dir}" | nc -4u -w0 127.0.0.1 8125 || true
 }
 
 main "$@"


### PR DESCRIPTION
Since we already have the datadog agent running in CI instances, we can send this metrics directly to datadog, this can help us keep track of checkout times for each repo.

Tested in: https://buildkite.com/canva-org/canva-check-merge/builds/378808

Metrics in datadog: https://app.datadoghq.com/metric/explorer?from_ts=1629167052704&to_ts=1629170350841&live=false&tile_size=m&exp_agg=avg&exp_row_type=metric&exp_metric=github.checkout_time&exp_scope=repo%3Acanva_canva

![image](https://user-images.githubusercontent.com/25152084/129662678-c76bd450-0d5d-48f8-a4bd-4d391db6c237.png)
