### PR TITLE
fix: ignored directories counts as a worktree directories

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -375,7 +375,7 @@ initialize_local_repo() {
   # If there is no local repository or the index is in a locked state.
   # When the lock file exists it's probably because a previous job was killed while checking out the
   # repo, in which case it might be corrupted.
-  elif [[ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" != "true" || -f ".git/index.lock" ]]; then
+  elif [[ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" != "true" || -n "$(git check-ignore .)" || -f ".git/index.lock" ]]; then
     if [[ -n "${BUILDKITE_PLUGIN_GITHUB_FETCH_S3_URL:-}" ]]; then
       copy_checkout_from_s3 "${BUILDKITE_PLUGIN_GITHUB_FETCH_S3_URL}"
       INITILISATION_METHOD=2


### PR DESCRIPTION
The plugin won't checkout a repository if we're currently in an ignored
directory of another repository. For example, let assume there's a
/opt/homebrew/ repository which has a var/buildkite-agent subdirectory,
ignored by the repo. If we cd into var/buildkite-agent, and run
git rev-parse --is-inside-work-tree, it will erroneously print "true". As a
result, the checkout plugin will operate on the /opt/homebrew repo and will
fail on the git clean step. To fix this, we need to ensure that the cwd is
not ignored by the repo.