### PR TITLE
Send ci source to goblet

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -25,6 +25,10 @@ GIT_REMOTE_TIMEOUT="${BUILDKITE_PLUGIN_GITHUB_FETCH_GIT_REMOTE_TIMEOUT:-0}"
 # If not specified by the user, it defaults to 110 which is the standard exit code for connection timeout.
 GIT_REMOTE_TIMEOUT_EXIT_CODE="${BUILDKITE_PLUGIN_GITHUB_FETCH_GIT_REMOTE_TIMEOUT_EXIT_CODE:-110}"
 
+# The "CI-Source" extra header that will be sent to git remote.
+# This helps correlate Buildkite logs and git remote logs (e.g. Goblet or Github.com)
+GIT_EXTRA_HEADER_CI_SOURCE="http.extraHeader=CI-Source: ${BUILDKITE_BUILD_URL}#${BUILDKITE_JOB_ID}"
+
 # Set to `true` forces a fresh clone from the remote to initialize the local copy for the first time
 # on the agent.
 #
@@ -290,7 +294,7 @@ checkout() {
   if [[ -z "${BUILDKITE_COMMIT:-}" || "${BUILDKITE_COMMIT}" == "HEAD" ]]; then
     log_info "Commit ID is not supplied. Fetch from HEAD."
     exit_code=0
-    GIT_TRACE=1 GIT_CURL_VERBOSE=1 log_and_run "${PLUGIN_DIR}/bin/timeout" "${GIT_REMOTE_TIMEOUT}" git fetch -v --no-tags origin "${BUILDKITE_BRANCH}" || exit_code=$?
+    GIT_TRACE=1 GIT_CURL_VERBOSE=1 log_and_run "${PLUGIN_DIR}/bin/timeout" "${GIT_REMOTE_TIMEOUT}" git fetch -c "${GIT_EXTRA_HEADER_CI_SOURCE}" -v --no-tags origin "${BUILDKITE_BRANCH}" || exit_code=$?
     check_timeout_exit_code "${exit_code}" "${GIT_REMOTE_TIMEOUT_EXIT_CODE}"
     if [[ "${exit_code}" -ne 0 ]]; then
       log_info "Git returned error code:${exit_code}"
@@ -309,7 +313,7 @@ checkout() {
 
     log_info "Fetch BUILDKITE_COMMIT=${BUILDKITE_COMMIT}"
     exit_code=0
-    GIT_TRACE=1 GIT_CURL_VERBOSE=1 log_and_run "${PLUGIN_DIR}/bin/timeout" "${GIT_REMOTE_TIMEOUT}" git fetch -v --no-tags origin "${BUILDKITE_COMMIT}" || exit_code=$?
+    GIT_TRACE=1 GIT_CURL_VERBOSE=1 log_and_run "${PLUGIN_DIR}/bin/timeout" "${GIT_REMOTE_TIMEOUT}" git fetch -c "${GIT_EXTRA_HEADER_CI_SOURCE}" -v --no-tags origin "${BUILDKITE_COMMIT}" || exit_code=$?
     check_timeout_exit_code "${exit_code}" "${GIT_REMOTE_TIMEOUT_EXIT_CODE}" || exit_code=$?
     # If the commit isn't there the ref that was pointing to it might have
     # been force pushed in the meantime. Exit with ESTALE to signify the stale
@@ -322,7 +326,7 @@ checkout() {
     elif [[ "${exit_code}" -ne 0 ]]; then
       log_info "Fail to checkout commit:${BUILDKITE_COMMIT}. Checkout branch:${BUILDKITE_BRANCH} instead."
       exit_code=0
-      GIT_TRACE=1 GIT_CURL_VERBOSE=1 log_and_run "${PLUGIN_DIR}/bin/timeout" "${GIT_REMOTE_TIMEOUT}" git fetch -v --no-tags origin "${BUILDKITE_BRANCH}" || exit_code=$?
+      GIT_TRACE=1 GIT_CURL_VERBOSE=1 log_and_run "${PLUGIN_DIR}/bin/timeout" "${GIT_REMOTE_TIMEOUT}" git fetch -c "${GIT_EXTRA_HEADER_CI_SOURCE}" -v --no-tags origin "${BUILDKITE_BRANCH}" || exit_code=$?
       check_timeout_exit_code "${exit_code}" "${GIT_REMOTE_TIMEOUT_EXIT_CODE}" || exit_code=$?
       if [[ "${exit_code}" -ne 0 ]]; then
         log_info "Git returned error code:${exit_code}"

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -294,7 +294,7 @@ checkout() {
   if [[ -z "${BUILDKITE_COMMIT:-}" || "${BUILDKITE_COMMIT}" == "HEAD" ]]; then
     log_info "Commit ID is not supplied. Fetch from HEAD."
     exit_code=0
-    GIT_TRACE=1 GIT_CURL_VERBOSE=1 log_and_run "${PLUGIN_DIR}/bin/timeout" "${GIT_REMOTE_TIMEOUT}" git fetch -c "${GIT_EXTRA_HEADER_CI_SOURCE}" -v --no-tags origin "${BUILDKITE_BRANCH}" || exit_code=$?
+    GIT_TRACE=1 GIT_CURL_VERBOSE=1 log_and_run "${PLUGIN_DIR}/bin/timeout" "${GIT_REMOTE_TIMEOUT}" git -c "${GIT_EXTRA_HEADER_CI_SOURCE}" fetch -v --no-tags origin "${BUILDKITE_BRANCH}" || exit_code=$?
     check_timeout_exit_code "${exit_code}" "${GIT_REMOTE_TIMEOUT_EXIT_CODE}"
     if [[ "${exit_code}" -ne 0 ]]; then
       log_info "Git returned error code:${exit_code}"
@@ -313,7 +313,7 @@ checkout() {
 
     log_info "Fetch BUILDKITE_COMMIT=${BUILDKITE_COMMIT}"
     exit_code=0
-    GIT_TRACE=1 GIT_CURL_VERBOSE=1 log_and_run "${PLUGIN_DIR}/bin/timeout" "${GIT_REMOTE_TIMEOUT}" git fetch -c "${GIT_EXTRA_HEADER_CI_SOURCE}" -v --no-tags origin "${BUILDKITE_COMMIT}" || exit_code=$?
+    GIT_TRACE=1 GIT_CURL_VERBOSE=1 log_and_run "${PLUGIN_DIR}/bin/timeout" "${GIT_REMOTE_TIMEOUT}" git -c "${GIT_EXTRA_HEADER_CI_SOURCE}" fetch -v --no-tags origin "${BUILDKITE_COMMIT}" || exit_code=$?
     check_timeout_exit_code "${exit_code}" "${GIT_REMOTE_TIMEOUT_EXIT_CODE}" || exit_code=$?
     # If the commit isn't there the ref that was pointing to it might have
     # been force pushed in the meantime. Exit with ESTALE to signify the stale
@@ -326,7 +326,7 @@ checkout() {
     elif [[ "${exit_code}" -ne 0 ]]; then
       log_info "Fail to checkout commit:${BUILDKITE_COMMIT}. Checkout branch:${BUILDKITE_BRANCH} instead."
       exit_code=0
-      GIT_TRACE=1 GIT_CURL_VERBOSE=1 log_and_run "${PLUGIN_DIR}/bin/timeout" "${GIT_REMOTE_TIMEOUT}" git fetch -c "${GIT_EXTRA_HEADER_CI_SOURCE}" -v --no-tags origin "${BUILDKITE_BRANCH}" || exit_code=$?
+      GIT_TRACE=1 GIT_CURL_VERBOSE=1 log_and_run "${PLUGIN_DIR}/bin/timeout" "${GIT_REMOTE_TIMEOUT}" git -c "${GIT_EXTRA_HEADER_CI_SOURCE}" fetch -v --no-tags origin "${BUILDKITE_BRANCH}" || exit_code=$?
       check_timeout_exit_code "${exit_code}" "${GIT_REMOTE_TIMEOUT_EXIT_CODE}" || exit_code=$?
       if [[ "${exit_code}" -ne 0 ]]; then
         log_info "Git returned error code:${exit_code}"


### PR DESCRIPTION
Now that we have partially rolled out Goblet to Canva/canva, it's important to know if a build failure is related to Goblet. And the reverse is true, if Goblet failed to serve a request, we want to get to the build quickly and check its logs. 

Therefore, the PR adds a `CI-Source` header to git fetch. Goblet will then log it in both Nginx and application logs. If proxy is not used, Github.com will receive this but won't do anything with it.

