### PR TITLE
Improve error message when fetch failed

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -336,7 +336,7 @@ checkout() {
     # been force pushed in the meantime. Exit with ESTALE to signify the stale
     # branch reference in that case.
     if [[ "${exit_code}" -eq 128 ]]; then
-      log_info "Fail to fetch commit:${BUILDKITE_COMMIT}. Check githublog under Artifacts tab for details."
+      log_info "Fail to fetch commit:${BUILDKITE_COMMIT}. Check ${git_log} under Artifacts tab for details."
       return 116
     # If checking out the commit fails, it might be because the commit isn't
     # being advertised. In that case fetch the branch instead.
@@ -357,7 +357,7 @@ checkout() {
     exit_code=0
     GIT_TRACE=1 GIT_CURL_VERBOSE=1 log_and_run git checkout -f "${BUILDKITE_COMMIT}" || exit_code=$?
     if [[ "${exit_code}" -eq 128 ]]; then
-      log_info "Fail to checkout commit:${BUILDKITE_COMMIT}. Check githublog under Artifacts tab for details."
+      log_info "Fail to checkout commit:${BUILDKITE_COMMIT}. Check ${git_log} under Artifacts tab for details."
       return 116
     elif [[ "${exit_code}" -ne 0 ]]; then
       log_info "Git returned unknown code:${exit_code}"

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -357,7 +357,7 @@ checkout() {
     exit_code=0
     GIT_TRACE=1 GIT_CURL_VERBOSE=1 log_and_run git checkout -f "${BUILDKITE_COMMIT}" || exit_code=$?
     if [[ "${exit_code}" -eq 128 ]]; then
-      log_info "Commit SHA ${BUILDKITE_COMMIT} does not exists. The ref might have been force pushed."
+      log_info "Fail to checkout commit:${BUILDKITE_COMMIT}. Check githublog under Artifacts tab for details."
       return 116
     elif [[ "${exit_code}" -ne 0 ]]; then
       log_info "Git returned unknown code:${exit_code}"

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -336,7 +336,7 @@ checkout() {
     # been force pushed in the meantime. Exit with ESTALE to signify the stale
     # branch reference in that case.
     if [[ "${exit_code}" -eq 128 ]]; then
-      log_info "Commit SHA ${BUILDKITE_COMMIT} does not exists. The ref might have been force pushed."
+      log_info "Fail to fetch commit:${BUILDKITE_COMMIT}. Check githublog under Artifacts tab for details."
       return 116
     # If checking out the commit fails, it might be because the commit isn't
     # being advertised. In that case fetch the branch instead.


### PR DESCRIPTION
Goblet has supported force push since https://github.com/Canva/goblet/pull/13

So when git fetch failed, mostly likely due to timeout on Goblet or Github, the error message `"Commit SHA ${BUILDKITE_COMMIT} does not exists. The ref might have been force pushed.` is no longer relevant, and it's causing confusions.

However, it's not possible to see the real reason of failure unless we parse the log, which is not trivial since we capture the whole log of the plugin invocation. (suggestions welcome though)

Therefore, I replaced the error message with `Fail to fetch commit:${BUILDKITE_COMMIT}. Check githublog under Artifacts tab for details.`. 

Slack
https://canva.slack.com/archives/C02661K3T1D/p1651034275132599

Jira
https://canvadev.atlassian.net/browse/SC-279