### PR TITLE
Don't check untracked when running status

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -298,7 +298,7 @@ checkout() {
   # Check the current state to make sure we start from a clean working tree.
   # This does both "refresh the index and updating the cached stat information"
   # as per `man git-status` **BACKGROUND REFRESH**.
-  git status
+  git status --untracked-files=no
 
   git config remote.origin.fetch
 


### PR DESCRIPTION
On large repositories enumerating untracked files can take a long time. We've already done a `git reset --hard` above so there's guaranteed to be no untracked files