### PR TITLE
Set build metadata if MAIN_REPO is set

### DIFF
--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -120,12 +120,13 @@ main() {
     repo_dir="$(print_repo_checkout_path "${MAIN_REPO}")"
     export BUILDKITE_PLUGIN_GITHUB_FETCH_S3_URL="${BUILDKITE_PLUGIN_GITHUB_FETCH_S3_URL}/${repo_dir}"
     export BUILDKITE_REPO="${MAIN_REPO}"
-    buildkite-agent meta-data set "MAIN_REPO" "${MAIN_REPO}"
   elif [[ -n "${SSM_PARAM:-}" ]]; then
     export_canva_origin_url
   else
     log_info "ssm param not configured skipping"
   fi
+
+  buildkite-agent meta-data set "CHECKOUT_REPO" "${BUILDKITE_REPO}"
 
   # DEPRECATED (app ID and secret will be removed, only export plain HTTPS urls from else case in the future)
   if [[ -n "${GITHUB_APP_ID:-}" ]] && [[ -n "${GITHUB_APP_SECRET:-}" ]]; then

--- a/hooks/pre-checkout
+++ b/hooks/pre-checkout
@@ -120,6 +120,7 @@ main() {
     repo_dir="$(print_repo_checkout_path "${MAIN_REPO}")"
     export BUILDKITE_PLUGIN_GITHUB_FETCH_S3_URL="${BUILDKITE_PLUGIN_GITHUB_FETCH_S3_URL}/${repo_dir}"
     export BUILDKITE_REPO="${MAIN_REPO}"
+    buildkite-agent meta-data set "MAIN_REPO" "${MAIN_REPO}"
   elif [[ -n "${SSM_PARAM:-}" ]]; then
     export_canva_origin_url
   else


### PR DESCRIPTION
webhook objects has no reference to the actual repo checked out if MAIN_REPO is set. This PR is to set the metadata MAIN_REPO so that it will be send with the webhook object.

Note: webhook object is the json data send from buildkite upon specific events. ([link](https://buildkite.com/docs/apis/webhooks)). The one which is concerned here is `job.finished` event.